### PR TITLE
Fix compilation error for kernel 4.2 and newer.

### DIFF
--- a/kernel-module-imx-gpu-viv-src/hal/os/linux/kernel/gc_hal_kernel_os.c
+++ b/kernel-module-imx-gpu-viv-src/hal/os/linux/kernel/gc_hal_kernel_os.c
@@ -6866,11 +6866,15 @@ gckOS_QueryProfileTickRate(
     OUT gctUINT64_PTR TickRate
     )
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
+    *TickRate = hrtimer_resolution;
+#else
     struct timespec res;
 
     hrtimer_get_res(CLOCK_MONOTONIC, &res);
 
     *TickRate = res.tv_nsec + res.tv_sec * 1000000000ULL;
+#endif
 
     return gcvSTATUS_OK;
 }


### PR DESCRIPTION
The function hrtimer_get_res() was removed in the following commit from the linux kernel:
http://git.kernel.org/cgit/linux/kernel/git/tip/tip.git/commit/?id=056a3cacbc46e5aca27b350ce4ecb3b33ebb0700
