### PR TITLE
fix for memory leak in gc_hal_kernel_os.c

### DIFF
--- a/kernel-module-imx-gpu-viv-src/hal/os/linux/kernel/gc_hal_kernel_os.c
+++ b/kernel-module-imx-gpu-viv-src/hal/os/linux/kernel/gc_hal_kernel_os.c
@@ -5049,6 +5049,10 @@ OnError:
                         if (!((physical - Os->device->baseAddress) & 0x80000000))
                         {
                             gctPHYS_ADDR_T gpuPhysical;
+                            
+                            kfree(ref);
+                            ref = gcvNULL;
+                            
                             kfree(pages);
                             pages = gcvNULL;
 


### PR DESCRIPTION
When the test (!((physical - Os->device->baseAddress) & 0x80000000)) returns true, the ref variable allocated line 4935 never get free'd and there is no more reference to it after that.