### PR TITLE
Make _GetProcessID fetch PIDs from the top-level PID namespace.

### DIFF
--- a/kernel-module-imx-gpu-viv-src/hal/os/linux/kernel/gc_hal_kernel_linux.h
+++ b/kernel-module-imx-gpu-viv-src/hal/os/linux/kernel/gc_hal_kernel_linux.h
@@ -326,7 +326,7 @@ _GetProcessID(
     )
 {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,24)
-    return task_tgid_vnr(current);
+    return task_tgid_nr_ns(current, &init_pid_ns);
 #else
     return current->tgid;
 #endif


### PR DESCRIPTION
This ensures that the returned process ID will uniquely identify a
process, regardless of which PID namespace a process belongs to.