### PR TITLE
Change return type of _QuerySignal() from gctBOOL -> gceSTATUS

### DIFF
--- a/kernel-module-imx-gpu-viv-src/hal/os/linux/kernel/gc_hal_kernel_linux.h
+++ b/kernel-module-imx-gpu-viv-src/hal/os/linux/kernel/gc_hal_kernel_linux.h
@@ -318,7 +318,7 @@ _ConvertLogical2Physical(
     OUT gctPHYS_ADDR_T * Physical
     );
 
-gctBOOL
+gceSTATUS
 _QuerySignal(
     IN gckOS Os,
     IN gctSIGNAL Signal


### PR DESCRIPTION
Fixes build errors found by gcc-13

  CC [M]  /mnt/b/yoe/master/build/tmp/work/imx8qm_var_som-yoe-linux/kernel-module-imx-gpu-viv/6.4.3.p4.6+fslc+gitAUTOINC+1adf982c59-r0/git/kernel-module-imx-gpu-viv-src/hal/os/linux/kernel/gc_hal_kernel_os.o
/mnt/b/yoe/master/build/tmp/work/imx8qm_var_som-yoe-linux/kernel-module-imx-gpu-viv/6.4.3.p4.6+fslc+gitAUTOINC+1adf982c59-r0/git/kernel-module-imx-gpu-viv-src/hal/os/linux/kernel/gc_hal_kernel_os.c:5875:1: error: conflicting types for '_QuerySignal' due to enum/integer mismatch; have 'gceSTATUS(struct _gckOS *, void *)' {aka 'enum _gceSTATUS(struct _gckOS *, void *)'} [-Werror=enum-int-mismatch]
 5875 | _QuerySignal(
      | ^~~~~~~~~~~~
In file included from /mnt/b/yoe/master/build/tmp/work/imx8qm_var_som-yoe-linux/kernel-module-imx-gpu-viv/6.4.3.p4.6+fslc+gitAUTOINC+1adf982c59-r0/git/kernel-module-imx-gpu-viv-src/hal/os/linux/kernel/gc_hal_kernel_os.c:56: /mnt/b/yoe/master/build/tmp/work/imx8qm_var_som-yoe-linux/kernel-module-imx-gpu-viv/6.4.3.p4.6+fslc+gitAUTOINC+1adf982c59-r0/git/kernel-module-imx-gpu-viv-src/hal/os/linux/kernel/gc_hal_kernel_linux.h:322:1: note: previous declaration of '_QuerySignal' with type 'gctBOOL(struct _gckOS *, void *)' {aka 'int(struct _gckOS *, void *)'}
  322 | _QuerySignal(
      | ^~~~~~~~~~~~
cc1: all warnings being treated as errors

Signed-off-by: Khem Raj <raj.khem@gmail.com>